### PR TITLE
fix: switch to Tailscale Auth Key for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,7 @@ jobs:
       - name: Tailscale
         uses: tailscale/github-action@v2
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
+          authkey: ${{ secrets.TAILSCALE_AUTH_KEY }}
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.0.3

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -4,16 +4,15 @@ Follow these steps one-by-one to enable automated deployments from GitHub to you
 
 ---
 
-### Step 1: Get Tailscale OAuth Credentials
-1.  Open your [Tailscale OAuth Settings](https://login.tailscale.com/admin/settings/oauth).
-2.  Click **"Generate OAuth client"**.
-3.  Under **Scopes**, select:
-    - `Devices` -> `Write`
-4.  (Optional but recommended) Under **Tags**, select or create a tag like `tag:ci`.
-5.  Click **"Generate client"**.
-6.  **COPY IMMEDIATELY**:
-    - Copy the **Client ID** and save it as `TS_OAUTH_CLIENT_ID` in GitHub.
-    - Copy the **Client Secret** and save it as `TS_OAUTH_SECRET` in GitHub.
+### Step 1: Get Tailscale Auth Key
+1.  Open your [Tailscale Keys Settings](https://login.tailscale.com/admin/settings/keys).
+2.  Click **"Generate auth key"**.
+3.  Set these options:
+    - **Reusable**: Yes (Turn this ON)
+    - **Ephemeral**: Yes
+    - **Tags**: Select `tag:ci`
+4.  Click **"Generate key"**.
+5.  **COPY IMMEDIATELY**: Save it as `TAILSCALE_AUTH_KEY` in GitHub Secrets.
 
 ---
 


### PR DESCRIPTION
## Deployment Fix: Switch to Tailscale Auth Key

This PR migrates the automated deployment workflow from Tailscale OAuth to **Auth Key** authentication. This fix is necessary because OAuth permission layers were causing 403 errors during the GitHub Actions connection phase.

### Changes:
- Updated `.github/workflows/deploy.yml` to use `TAILSCALE_AUTH_KEY`.
- Updated `docs/DEPLOYMENT_SETUP.md` with instructions for generating the Auth Key.

**Merging this PR will trigger the deployment using the new Auth Key you just added to GitHub Secrets.**