### PR TITLE
fix: robust git strategy for deployment script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,7 +8,8 @@ cd "$BASE_DIR"
 echo "🚀 Starting Deployment..."
 
 echo "📥 Pulling latest changes..."
-git pull origin main
+git fetch origin main
+git reset --hard origin/main
 
 echo "🐍 Running migrations..."
 ./venv/bin/python3 scripts/db_manager.py migrate


### PR DESCRIPTION
## Robust Deployment Script

This PR updates the `scripts/deploy.sh` to use a more robust git strategy: `git fetch` followed by `git reset --hard`.

### Why?
Earlier deployments failed because the Raspberry Pi's local `main` branch had diverged from the remote. This often happens in automated environments when historical commits change (like our recent rebases).

### Solution:
By using `git reset --hard origin/main`, we ensure the Pi's code **always** exactly matches the production code on GitHub, no matter what.

**Merge this to finally get that full Green deployment!** 🚀